### PR TITLE
fix: remove @container from identifiedBy definition

### DIFF
--- a/issn-jsonld-context.json
+++ b/issn-jsonld-context.json
@@ -53,8 +53,7 @@
     },
     "identifiedBy" : {
       "@id" : "bf:identifiedBy",
-      "@type" : "@id",
-      "@container": "@id"
+      "@type" : "@id"
     },
     "mainTitle" : {
       "@id" : "bf:mainTitle",


### PR DESCRIPTION
The "@container": "@id" directive on the identifiedBy property causes strict JSON-LD parsers (like RDFLib 7.0+) to drop internal node data when the input data is a simple object instead of a map. Removing this directive ensures compatibility with modern RDF tools while maintaining the correct semantic mapping to bibframe.

See : https://github.com/RDFLib/rdflib/issues/3157